### PR TITLE
Ephemeral-bump release workflow + version placeholder 0.0.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,9 +26,11 @@ jobs:
 
       - run: npm run build
 
-      # Packaging validation — green CI ⟹ publishable. Catches missing dist,
-      # wrong exports, bad files globs at PR time, not at the irreversible step.
-      - run: npm publish --dry-run --access public
+      # Packaging validation — green CI ⟹ publishable. Validates the exact
+      # tarball (files globs, exports, dist present) without contacting the
+      # registry, so it does not fail on the placeholder 0.0.0 version. The
+      # release workflow handles version-uniqueness separately.
+      - run: npm pack --dry-run
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,16 +1,17 @@
 name: Release & Publish
 
 # Manually triggered release for @fyre-db/core.
-# You provide the version + release notes; this workflow validates, bumps
-# package.json on main, tags, publishes to npm (with provenance), and creates
-# the GitHub Release — all with the correct version in every place.
+# You provide the version + release notes; this workflow validates, publishes to
+# npm (with provenance), tags the current main commit, and creates the GitHub
+# Release. The version bump is *ephemeral* — package.json is bumped only inside
+# the runner for the publish; it is never committed back to main. The git tag is
+# the source of truth for the released version. main/package.json stays at the
+# placeholder 0.0.0.
 #
 # Requirements:
 #   - Runs only from `main`.
-#   - secrets.RELEASE_TOKEN: a GitHub App installation token (or fine-grained
-#     PAT) allowed to push to `main` via a branch-protection bypass. The default
-#     GITHUB_TOKEN cannot push to a protected branch.
 #   - npm Trusted Publishing (OIDC) configured for @fyre-db/core (no npm token).
+#   - No push to a protected branch — no secret/PAT/bypass needed.
 
 on:
   workflow_dispatch:
@@ -26,7 +27,7 @@ on:
 
 permissions:
   id-token: write # OIDC for npm provenance
-  contents: write # create tag + GitHub Release (push uses RELEASE_TOKEN)
+  contents: write # create the git tag + GitHub Release (no branch push)
 
 concurrency:
   group: release-${{ github.ref }}
@@ -42,7 +43,6 @@ jobs:
         with:
           ref: main
           fetch-depth: 0
-          token: ${{ secrets.RELEASE_TOKEN }}
 
       - name: Validate version input
         run: |
@@ -80,24 +80,19 @@ jobs:
       - run: npm run lint
       - run: npm run test
       - run: npm run build
+
+      - name: Ephemeral version bump (runner-only, not committed)
+        run: npm version "$VERSION" --no-git-tag-version
+
       - run: npm publish --dry-run --access public
-
-      - name: Bump version on main
-        run: |
-          npm version "$VERSION" --no-git-tag-version
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add package.json package-lock.json 2>/dev/null || git add package.json
-          git commit -m "chore(release): v${VERSION}"
-          git push origin main
-
-      - name: Tag the release commit
-        run: |
-          git tag "v${VERSION}"
-          git push origin "v${VERSION}"
 
       - name: Publish to npm
         run: npm publish --provenance --access public
+
+      - name: Tag the released main commit
+        run: |
+          git tag "v${VERSION}"
+          git push origin "v${VERSION}"
 
       - name: Create GitHub Release
         env:
@@ -109,4 +104,5 @@ jobs:
             --target main \
             --title "v${VERSION}" \
             --notes "$NOTES"
+
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fyre-db/core",
-  "version": "0.0.1",
+  "version": "0.0.0",
   "description": "Offline-first reactive data framework — the @fyre-db core",
   "homepage": "https://github.com/fyre-db/core#readme",
   "bugs": {


### PR DESCRIPTION
Reworks the release flow so it never pushes to protected `main` — no `RELEASE_TOKEN` / bypass needed.

## Changes
- **publish.yml**: version bump is now **ephemeral** — `npm version` runs in the runner only, used for `npm publish --provenance`, and is **not committed back to main**. The flow validates -> lint/test/build -> publish -> **tag the main commit** -> create GitHub Release. Uses the default `GITHUB_TOKEN` (tags/releases only, no branch push).
- **package.json**: version set to **0.0.0** placeholder. The git tag / GitHub Release / npm are the source of truth for the real published version; main's package.json stays at 0.0.0.

## Why
Branch protection on `main` only allows the GitHub merge queue to bypass (not the Actions app), so the previous 'bump + push to main' flow couldn't work without a PAT. Ephemeral bump keeps protection fully strict with zero secrets.

## Release flow after merge
Actions -> **Release & Publish** -> enter version (e.g. `0.1.0`) + notes -> publishes to npm, tags `v0.1.0`, creates the Release.