### PR TITLE
Fix release-notes shell interpolation in publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -97,12 +97,17 @@ jobs:
       - name: Create GitHub Release
         env:
           GH_TOKEN: ${{ github.token }}
+          # Pass notes via env (not inline) so backticks/quotes/newlines in the
+          # markdown are never interpreted by the shell.
+          RELEASE_NOTES: ${{ inputs.notes }}
         run: |
-          NOTES="${{ inputs.notes }}"
-          if [ -z "$NOTES" ]; then NOTES="Release v${VERSION}"; fi
+          if [ -z "$RELEASE_NOTES" ]; then
+            RELEASE_NOTES="Release v${VERSION}"
+          fi
+          printf '%s' "$RELEASE_NOTES" > "$RUNNER_TEMP/release-notes.md"
           gh release create "v${VERSION}" \
             --target main \
             --title "v${VERSION}" \
-            --notes "$NOTES"
+            --notes-file "$RUNNER_TEMP/release-notes.md"
 
 


### PR DESCRIPTION
The 'Create GitHub Release' step inlined inputs.notes directly into the bash script, so backticks in the markdown (e.g. code spans like FyreDbError) were executed as commands -> 'command not found' and the step failed (exit 127).

Fix: pass notes through an env var (RELEASE_NOTES) and write to a file via --notes-file, so the shell never parses the markdown.

Note: v0.1.0 was already published to npm and tagged; only the GitHub Release creation failed and was created manually. This prevents recurrence on the next release.