### PR TITLE
feat(sync): edit-driven local flush and cloud sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,8 +70,11 @@ const fyredb = new FyreDb({
   encryptionService: myEncryption,    // optional — enables per-tenant encryption
   migrations: [...],                  // optional — blob migrations
   options: {
-    localFlushIntervalMs: 2000,       // memory → local flush interval (default: 2s)
-    cloudSyncIntervalMs: 300000,      // local → cloud sync interval (default: 5m)
+    localFlushDebounceMs: 500,        // memory → local, after edits settle (default: 500ms)
+    localFlushMaxWaitMs: 3000,        // local flush ceiling during sustained edits (default: 3s)
+    cloudSyncDebounceMs: 10000,       // cloud sync, after edits settle (default: 10s)
+    cloudSyncMaxWaitMs: 60000,        // cloud sync ceiling (default: 60s)
+    cloudPullIntervalMs: 300000,      // periodic pull backstop (default: 5m)
     tombstoneRetentionMs: 604800000,  // tombstone TTL (default: 7 days)
   },
 });

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -103,8 +103,11 @@ const fyredb = new FyreDb({
   encryptionService: myEncryption,    // optional — enables per-tenant encryption
   migrations: [...],                  // optional — blob migrations
   options: {
-    localFlushIntervalMs: 2000,       // memory → local flush interval (default: 2s)
-    cloudSyncIntervalMs: 300000,      // local → cloud sync interval (default: 5m)
+    localFlushDebounceMs: 500,        // memory → local, after edits settle (default: 500ms)
+    localFlushMaxWaitMs: 3000,        // local flush ceiling during sustained edits (default: 3s)
+    cloudSyncDebounceMs: 10000,       // cloud sync, after edits settle (default: 10s)
+    cloudSyncMaxWaitMs: 60000,        // cloud sync ceiling (default: 60s)
+    cloudPullIntervalMs: 300000,      // periodic pull backstop (default: 5m)
     tombstoneRetentionMs: 604800000,  // tombstone TTL (default: 7 days)
   },
 });

--- a/docs/sync.md
+++ b/docs/sync.md
@@ -29,21 +29,27 @@ When you call `fyredb.tenants.open(id)`, the framework:
 2. Syncs local → memory (loads entities into Map)
 3. If cloud is unreachable, loads from local only and emits a `sync-failed` event
 
-### 2. Periodic (background)
+### 2. Edit-driven (background)
 
-| Direction | Interval | Default |
-|-----------|----------|---------|
-| memory → local | `localFlushIntervalMs` | 2 seconds |
-| local → cloud | `cloudSyncIntervalMs` | 5 minutes |
+| Direction | Trigger | Default window |
+|-----------|---------|----------------|
+| memory → local | debounced on user edits | 500ms settle / 3s ceiling |
+| memory → local → cloud → memory | debounced on user edits | 10s settle / 60s ceiling |
+| local → cloud → memory (pull backstop) | periodic timer `cloudPullIntervalMs` | 5 minutes |
 
-After cloud sync, local → memory is run to merge any remote changes back into the app.
+User edits arm both debouncers; the cloud cycle also runs on a periodic pull
+timer so an idle device still receives remote changes. After each cloud cycle,
+local → memory merges remote changes back into the app.
 
 ```typescript
 const fyredb = new FyreDb({
   // ...
   options: {
-    localFlushIntervalMs: 2000,    // default: 2s
-    cloudSyncIntervalMs: 300000,   // default: 5m
+    localFlushDebounceMs: 500,     // default: 500ms
+    localFlushMaxWaitMs: 3000,     // default: 3s
+    cloudSyncDebounceMs: 10000,    // default: 10s
+    cloudSyncMaxWaitMs: 60000,     // default: 60s
+    cloudPullIntervalMs: 300000,   // default: 5m
   },
 });
 ```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fyre-db/core",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Offline-first reactive data framework — the @fyre-db core",
   "homepage": "https://github.com/fyre-db/core#readme",
   "bugs": {

--- a/src/fyredb.ts
+++ b/src/fyredb.ts
@@ -143,9 +143,13 @@ export class FyreDb {
       rawCloudAdapter: config.cloudAdapter,
     });
 
+    // `isDirty` means "changes not yet in the cloud". Without a cloud adapter,
+    // the periodic memory→local flush is the durable save, so there is nothing
+    // to be pending against — never set the flag in local-only mode.
+    const hasCloud = cloudAdapter !== undefined;
     this.dirtySubscription = this.eventBus.all$.pipe(
       filter(e => e.source !== 'sync'),
-    ).subscribe(() => { this.dirtyTracker.set(); });
+    ).subscribe(() => { if (hasCloud) this.dirtyTracker.set(); });
 
     // Re-emit sync errors that are FyreDbErrors onto the errorBus so consumers
     // get a single channel for all data-op errors regardless of source.

--- a/src/options.ts
+++ b/src/options.ts
@@ -1,6 +1,9 @@
 export type FyreDbOptions = {
-  readonly cloudSyncIntervalMs?: number;
-  readonly localFlushIntervalMs?: number;
+  readonly localFlushDebounceMs?: number;
+  readonly localFlushMaxWaitMs?: number;
+  readonly cloudSyncDebounceMs?: number;
+  readonly cloudSyncMaxWaitMs?: number;
+  readonly cloudPullIntervalMs?: number;
   readonly tombstoneRetentionMs?: number;
   readonly tenantKey?: string;
   readonly markerKey?: string;
@@ -22,13 +25,36 @@ export function resolveOptions(opts?: FyreDbOptions): ResolvedFyreDbOptions {
   if (tombstoneRetentionMs < 0 || !Number.isFinite(tombstoneRetentionMs)) {
     throw new FyreDbConfigError(`Invalid tombstoneRetentionMs: ${tombstoneRetentionMs}. Must be a finite non-negative number.`);
   }
-  const cloudSyncIntervalMs = opts?.cloudSyncIntervalMs ?? 300_000;
-  validatePositiveInterval('cloudSyncIntervalMs', cloudSyncIntervalMs);
-  const localFlushIntervalMs = opts?.localFlushIntervalMs ?? 2_000;
-  validatePositiveInterval('localFlushIntervalMs', localFlushIntervalMs);
+
+  // Local flush: memory → local, edit-driven (debounce + ceiling).
+  const localFlushDebounceMs = opts?.localFlushDebounceMs ?? 500;
+  validatePositiveInterval('localFlushDebounceMs', localFlushDebounceMs);
+  const localFlushMaxWaitMs = opts?.localFlushMaxWaitMs ?? 3_000;
+  validatePositiveInterval('localFlushMaxWaitMs', localFlushMaxWaitMs);
+  if (localFlushMaxWaitMs < localFlushDebounceMs) {
+    throw new FyreDbConfigError(`localFlushMaxWaitMs (${localFlushMaxWaitMs}) must be >= localFlushDebounceMs (${localFlushDebounceMs}).`);
+  }
+
+  // Cloud sync: local ↔ cloud, edit-driven (debounce + ceiling).
+  const cloudSyncDebounceMs = opts?.cloudSyncDebounceMs ?? 10_000;
+  validatePositiveInterval('cloudSyncDebounceMs', cloudSyncDebounceMs);
+  const cloudSyncMaxWaitMs = opts?.cloudSyncMaxWaitMs ?? 60_000;
+  validatePositiveInterval('cloudSyncMaxWaitMs', cloudSyncMaxWaitMs);
+  if (cloudSyncMaxWaitMs < cloudSyncDebounceMs) {
+    throw new FyreDbConfigError(`cloudSyncMaxWaitMs (${cloudSyncMaxWaitMs}) must be >= cloudSyncDebounceMs (${cloudSyncDebounceMs}).`);
+  }
+
+  // Cloud pull: periodic backstop that fetches remote changes when this device
+  // is idle (no local edits to trigger an edit-driven cloud sync).
+  const cloudPullIntervalMs = opts?.cloudPullIntervalMs ?? 300_000;
+  validatePositiveInterval('cloudPullIntervalMs', cloudPullIntervalMs);
+
   return {
-    cloudSyncIntervalMs,
-    localFlushIntervalMs,
+    localFlushDebounceMs,
+    localFlushMaxWaitMs,
+    cloudSyncDebounceMs,
+    cloudSyncMaxWaitMs,
+    cloudPullIntervalMs,
     tombstoneRetentionMs,
     tenantKey: opts?.tenantKey ?? '__tenants',
     markerKey: opts?.markerKey ?? '__fyredb',

--- a/src/sync/sync-engine.ts
+++ b/src/sync/sync-engine.ts
@@ -9,6 +9,8 @@ import type { BlobMigration } from '@/schema/migration';
 import type { DataAdapter, AllIndexes } from '@/persistence';
 import { parseCompositeKey } from '@/utils';
 import type { ReactiveFlag } from '@/utils';
+import { Debouncer } from '@/utils';
+import type { Subscription } from 'rxjs';
 import type { ResolvedFyreDbOptions } from '../options';
 import { SyncError } from './errors';
 import { FyreDbError } from '@/errors';
@@ -184,9 +186,24 @@ export class SyncEngine {
 
   // ── Scheduler ──────────────────────────────────────────
 
-  private localTimer: ReturnType<typeof setInterval> | null = null;
   private cloudTimer: ReturnType<typeof setInterval> | null = null;
+  private localDebouncer: Debouncer | null = null;
+  private cloudDebouncer: Debouncer | null = null;
+  private editSub: Subscription | null = null;
 
+  /**
+   * Start edit-driven persistence for the active tenant.
+   *
+   * - **Local flush** (`memory → local`): debounced on user edits.
+   * - **Cloud sync** (`memory → local → cloud → memory`): debounced on user
+   *   edits, so pushes happen shortly after editing settles instead of on a
+   *   fixed cadence.
+   * - **Cloud pull backstop**: a periodic timer runs the same cloud cycle so an
+   *   idle device (making no edits) still receives remote changes.
+   *
+   * Only non-`sync` (user-originated) entity events arm the debouncers, so
+   * imported remote changes never re-trigger a sync.
+   */
   startScheduler(
     tenant: Tenant | undefined,
     hasCloud: boolean,
@@ -197,41 +214,69 @@ export class SyncEngine {
     }
     this.stopScheduler();
 
-    this.localTimer = setInterval(() => {
-      this.sync('memory', 'local', tenant).catch((err: unknown) => {
-        log.sync.error('local flush failed: %O', err);
-      });
-    }, this.options.localFlushIntervalMs);
+    this.localDebouncer = new Debouncer(
+      () => { this.flushLocal(tenant); },
+      this.options.localFlushDebounceMs,
+      this.options.localFlushMaxWaitMs,
+    );
 
     if (hasCloud) {
+      this.cloudDebouncer = new Debouncer(
+        () => { this.runCloudCycle(tenant, dirtyTracker); },
+        this.options.cloudSyncDebounceMs,
+        this.options.cloudSyncMaxWaitMs,
+      );
       this.cloudTimer = setInterval(() => {
-        void (async () => {
-          try {
-            await this.sync('local', 'cloud', tenant);
-            await this.sync('local', 'memory', tenant);
-            dirtyTracker?.clear();
-          } catch (err) {
-            log.sync.error('cloud sync failed: %O', err);
-          }
-        })();
-      }, this.options.cloudSyncIntervalMs);
+        this.runCloudCycle(tenant, dirtyTracker);
+      }, this.options.cloudPullIntervalMs);
     }
 
-    log.sync('scheduler started (local=%dms, cloud=%dms)',
-      this.options.localFlushIntervalMs,
-      this.options.cloudSyncIntervalMs,
+    this.editSub = this.entityEventBus.all$.subscribe((evt) => {
+      if (evt.source === 'sync') return;
+      this.localDebouncer?.schedule();
+      this.cloudDebouncer?.schedule();
+    });
+
+    log.sync('scheduler started (local=%d/%dms, cloud=%d/%dms, pull=%dms)',
+      this.options.localFlushDebounceMs, this.options.localFlushMaxWaitMs,
+      this.options.cloudSyncDebounceMs, this.options.cloudSyncMaxWaitMs,
+      this.options.cloudPullIntervalMs,
     );
   }
 
   stopScheduler(): void {
-    if (this.localTimer !== null) {
-      clearInterval(this.localTimer);
-      this.localTimer = null;
-    }
+    this.editSub?.unsubscribe();
+    this.editSub = null;
+    this.localDebouncer?.cancel();
+    this.localDebouncer = null;
+    this.cloudDebouncer?.cancel();
+    this.cloudDebouncer = null;
     if (this.cloudTimer !== null) {
       clearInterval(this.cloudTimer);
       this.cloudTimer = null;
     }
+  }
+
+  private flushLocal(tenant: Tenant | undefined): void {
+    this.sync('memory', 'local', tenant).catch((err: unknown) => {
+      log.sync.error('local flush failed: %O', err);
+    });
+  }
+
+  private runCloudCycle(
+    tenant: Tenant | undefined,
+    dirtyTracker?: ReactiveFlag,
+  ): void {
+    void (async () => {
+      try {
+        await this.sync('memory', 'local', tenant);
+        await this.sync('local', 'cloud', tenant);
+        await this.sync('local', 'memory', tenant);
+        dirtyTracker?.clear();
+      } catch (err) {
+        log.sync.error('cloud sync failed: %O', err);
+      }
+    })();
   }
 
   // ── Lazy hydration ─────────────────────────────────────

--- a/src/sync/sync-engine.ts
+++ b/src/sync/sync-engine.ts
@@ -17,7 +17,7 @@ import { FyreDbError } from '@/errors';
 import type {
   SyncLocation, SyncQueueItem, SyncEvent,
   SyncEnqueueResult, SyncBetweenResult,
-  SyncEntityChange,
+  SyncEntityChange, SyncResult,
 } from './types';
 import { syncBetween } from './unified';
 import type { PartitionFilter } from './unified';
@@ -222,12 +222,12 @@ export class SyncEngine {
 
     if (hasCloud) {
       this.cloudDebouncer = new Debouncer(
-        () => { this.runCloudCycle(tenant, dirtyTracker); },
+        () => { void this.runCloudCycle(tenant, dirtyTracker).catch(() => {}); },
         this.options.cloudSyncDebounceMs,
         this.options.cloudSyncMaxWaitMs,
       );
       this.cloudTimer = setInterval(() => {
-        this.runCloudCycle(tenant, dirtyTracker);
+        void this.runCloudCycle(tenant, dirtyTracker).catch(() => {});
       }, this.options.cloudPullIntervalMs);
     }
 
@@ -247,7 +247,8 @@ export class SyncEngine {
   stopScheduler(): void {
     this.editSub?.unsubscribe();
     this.editSub = null;
-    this.localDebouncer?.cancel();
+    // Flush (not cancel) any pending local write so stopping never drops edits.
+    this.localDebouncer?.flush();
     this.localDebouncer = null;
     this.cloudDebouncer?.cancel();
     this.cloudDebouncer = null;
@@ -263,20 +264,31 @@ export class SyncEngine {
     });
   }
 
-  private runCloudCycle(
+  /**
+   * Run the full cloud sync cycle: `memory → local → cloud → memory`, then
+   * clear the dirty tracker on success. Errors from individual steps are
+   * already emitted as `sync-failed` events by `sync()` and are re-thrown here
+   * so awaiting callers (e.g. `TenantManager.sync()`) can react.
+   *
+   * The step-level dedup inside `sync()` collapses overlapping cycles from any
+   * combination of callers (debouncer, pull backstop timer, manual sync).
+   */
+  async runCloudCycle(
     tenant: Tenant | undefined,
     dirtyTracker?: ReactiveFlag,
-  ): void {
-    void (async () => {
-      try {
-        await this.sync('memory', 'local', tenant);
-        await this.sync('local', 'cloud', tenant);
-        await this.sync('local', 'memory', tenant);
-        dirtyTracker?.clear();
-      } catch (err) {
-        log.sync.error('cloud sync failed: %O', err);
-      }
-    })();
+  ): Promise<SyncResult> {
+    const results = await this.run(tenant, [
+      ['memory', 'local'],
+      ['local', 'cloud'],
+      ['local', 'memory'],
+    ]);
+    dirtyTracker?.clear();
+    const cloud = results[1];
+    return {
+      entitiesUpdated: cloud.changesForB.length,
+      conflictsResolved: cloud.changesForA.length,
+      partitionsSynced: cloud.changesForA.length + cloud.changesForB.length,
+    };
   }
 
   // ── Lazy hydration ─────────────────────────────────────

--- a/src/sync/types.ts
+++ b/src/sync/types.ts
@@ -81,6 +81,10 @@ export type SyncEngine = {
     tenant: Tenant | undefined,
     steps: ReadonlyArray<[SyncLocation, SyncLocation]>,
   ): Promise<SyncBetweenResult[]>;
+  runCloudCycle(
+    tenant: Tenant | undefined,
+    dirtyTracker?: ReactiveFlag,
+  ): Promise<SyncResult>;
   ensurePartition(
     tenant: Tenant | undefined,
     entityName: string,

--- a/src/tenant/tenant-manager.ts
+++ b/src/tenant/tenant-manager.ts
@@ -288,18 +288,7 @@ export class TenantManager implements TenantManagerType {
     if (!tenant) throw new TenantError('No tenant loaded', { kind: 'no-tenant-loaded' });
     if (!this.deps.cloudAdapter) throw new SyncError('No cloud adapter configured', { kind: 'cloud-not-configured' });
 
-    const results = await this.deps.syncEngine.run(tenant, [
-      ['memory', 'local'],
-      ['local', 'cloud'],
-      ['local', 'memory'],
-    ]);
-    this.deps.dirtyTracker.clear();
-    const cloudResult = results[1];
-    return {
-      entitiesUpdated: cloudResult.changesForB.length,
-      conflictsResolved: cloudResult.changesForA.length,
-      partitionsSynced: cloudResult.changesForA.length + cloudResult.changesForB.length,
-    };
+    return this.deps.syncEngine.runCloudCycle(tenant, this.deps.dirtyTracker);
   }
 
   // Security note: credential strings cannot be zeroed in JS — see open() comment.

--- a/src/utils/debouncer.ts
+++ b/src/utils/debouncer.ts
@@ -1,0 +1,49 @@
+/**
+ * Trailing debounce with a maximum-wait ceiling.
+ *
+ * `schedule()` (re)arms a trailing timer that fires `fn` after `waitMs` of quiet
+ * since the most recent call. To stop a continuous stream of calls from
+ * deferring `fn` forever, the first `schedule()` in a burst also arms a ceiling
+ * timer that fires `fn` no later than `maxWaitMs` later. Whichever fires first
+ * runs `fn` and clears both timers, ending the burst.
+ */
+export class Debouncer {
+  private timer: ReturnType<typeof setTimeout> | null = null;
+  private maxTimer: ReturnType<typeof setTimeout> | null = null;
+
+  constructor(
+    private readonly fn: () => void,
+    private readonly waitMs: number,
+    private readonly maxWaitMs: number,
+  ) {}
+
+  /** Arm (or re-arm) the trailing timer; start the ceiling timer on first call. */
+  schedule(): void {
+    if (this.timer !== null) clearTimeout(this.timer);
+    this.timer = setTimeout(() => { this.fire(); }, this.waitMs);
+    if (this.maxTimer === null) {
+      this.maxTimer = setTimeout(() => { this.fire(); }, this.maxWaitMs);
+    }
+  }
+
+  /** Whether a call is currently pending. */
+  get pending(): boolean {
+    return this.timer !== null || this.maxTimer !== null;
+  }
+
+  /** Run `fn` immediately if a call is pending; otherwise do nothing. */
+  flush(): void {
+    if (this.pending) this.fire();
+  }
+
+  /** Cancel any pending call without invoking `fn`. */
+  cancel(): void {
+    if (this.timer !== null) { clearTimeout(this.timer); this.timer = null; }
+    if (this.maxTimer !== null) { clearTimeout(this.maxTimer); this.maxTimer = null; }
+  }
+
+  private fire(): void {
+    this.cancel();
+    this.fn();
+  }
+}

--- a/src/utils/debouncer.ts
+++ b/src/utils/debouncer.ts
@@ -26,14 +26,9 @@ export class Debouncer {
     }
   }
 
-  /** Whether a call is currently pending. */
-  get pending(): boolean {
-    return this.timer !== null || this.maxTimer !== null;
-  }
-
   /** Run `fn` immediately if a call is pending; otherwise do nothing. */
   flush(): void {
-    if (this.pending) this.fire();
+    if (this.timer !== null || this.maxTimer !== null) this.fire();
   }
 
   /** Cancel any pending call without invoking `fn`. */

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -4,5 +4,6 @@ export { generateId } from './id';
 export { assertNotDisposed } from './assert';
 export { serialize, deserialize } from './serialize';
 export { ReactiveFlag } from './reactive-flag';
+export { Debouncer } from './debouncer';
 export { FNV_OFFSET, FNV_PRIME, fnv1a, fnv1aAppend, fnvHash } from './fnv';
 export { compareValues, valuesEqual } from './compare';

--- a/tests/fyredb.test.ts
+++ b/tests/fyredb.test.ts
@@ -899,6 +899,11 @@ describe('FyreDb', () => {
       expect(() => resolveOptions({ localFlushDebounceMs: 1000, localFlushMaxWaitMs: 500 }))
         .toThrow('localFlushMaxWaitMs');
     });
+
+    it('rejects cloudSyncMaxWaitMs below the debounce window', () => {
+      expect(() => resolveOptions({ cloudSyncDebounceMs: 10000, cloudSyncMaxWaitMs: 5000 }))
+        .toThrow('cloudSyncMaxWaitMs');
+    });
   });
 });
 

--- a/tests/fyredb.test.ts
+++ b/tests/fyredb.test.ts
@@ -407,6 +407,7 @@ describe('FyreDb', () => {
         appId: 'test',
         entities: [taskDef],
         localAdapter: makeAdapter(),
+        cloudAdapter: makeAdapter(),
         deviceId: 'dev',
       });
       const tenant = await fyredb.tenants.create({
@@ -418,6 +419,25 @@ describe('FyreDb', () => {
       const repo = fyredb.repo(taskDef) as Repository<Task>;
       repo.save({ title: 'Test', done: false });
       expect(fyredb.isDirty).toBe(true);
+    });
+
+    it('stays clean in local-only mode (no cloud adapter)', async () => {
+      const taskDef = defineEntity<Task>('task');
+      fyredb = new FyreDb({
+        appId: 'test',
+        entities: [taskDef],
+        localAdapter: makeAdapter(),
+        deviceId: 'dev',
+      });
+      const tenant = await fyredb.tenants.create({
+        name: 'Test',
+        meta: { bucket: 'test' },
+      });
+      await fyredb.tenants.open(tenant.id);
+
+      const repo = fyredb.repo(taskDef) as Repository<Task>;
+      repo.save({ title: 'Test', done: false });
+      expect(fyredb.isDirty).toBe(false);
     });
 
     it('clears after sync', async () => {
@@ -860,19 +880,24 @@ describe('FyreDb', () => {
       expect(opts.tombstoneRetentionMs).toBe(0);
     });
 
-    it('rejects zero cloudSyncIntervalMs', () => {
-      expect(() => resolveOptions({ cloudSyncIntervalMs: 0 }))
-        .toThrow('Invalid cloudSyncIntervalMs');
+    it('rejects zero cloudPullIntervalMs', () => {
+      expect(() => resolveOptions({ cloudPullIntervalMs: 0 }))
+        .toThrow('Invalid cloudPullIntervalMs');
     });
 
-    it('rejects negative localFlushIntervalMs', () => {
-      expect(() => resolveOptions({ localFlushIntervalMs: -100 }))
-        .toThrow('Invalid localFlushIntervalMs');
+    it('rejects negative localFlushDebounceMs', () => {
+      expect(() => resolveOptions({ localFlushDebounceMs: -100 }))
+        .toThrow('Invalid localFlushDebounceMs');
     });
 
-    it('rejects Infinity cloudSyncIntervalMs', () => {
-      expect(() => resolveOptions({ cloudSyncIntervalMs: Infinity }))
-        .toThrow('Invalid cloudSyncIntervalMs');
+    it('rejects Infinity cloudSyncDebounceMs', () => {
+      expect(() => resolveOptions({ cloudSyncDebounceMs: Infinity }))
+        .toThrow('Invalid cloudSyncDebounceMs');
+    });
+
+    it('rejects localFlushMaxWaitMs below the debounce window', () => {
+      expect(() => resolveOptions({ localFlushDebounceMs: 1000, localFlushMaxWaitMs: 500 }))
+        .toThrow('localFlushMaxWaitMs');
     });
   });
 });

--- a/tests/integration/lifecycle.test.ts
+++ b/tests/integration/lifecycle.test.ts
@@ -86,7 +86,7 @@ describe('Full lifecycle integration', () => {
       entities: [TaskDef],
       localAdapter,
       deviceId: 'dev-1',
-      options: { localFlushIntervalMs: 60000 }, // Long debounce to ensure data isn't flushed before dispose
+      options: { localFlushDebounceMs: 60000, localFlushMaxWaitMs: 60000 }, // Long debounce to ensure data isn't flushed before dispose
     }));
     const tenant = await fyredb.tenants.create({ name: 'W', meta });
     await fyredb.tenants.open(tenant.id);

--- a/tests/integration/multi-tenant-parallel-sync.test.ts
+++ b/tests/integration/multi-tenant-parallel-sync.test.ts
@@ -328,8 +328,11 @@ describe('Multi-tenant parallel sync integration', () => {
       cloudAdapter: sharedCloud,
       deviceId: 'dev-1',
       options: {
-        localFlushIntervalMs: 50,
-        cloudSyncIntervalMs: 100,
+        localFlushDebounceMs: 20,
+        localFlushMaxWaitMs: 50,
+        cloudSyncDebounceMs: 20,
+        cloudSyncMaxWaitMs: 50,
+        cloudPullIntervalMs: 100,
       },
     }));
 

--- a/tests/sync/sync-engine.test.ts
+++ b/tests/sync/sync-engine.test.ts
@@ -540,7 +540,7 @@ describe('SyncEngine scheduler', () => {
     engine.stopScheduler();
   });
 
-  it('stopScheduler cancels a pending debounced flush', () => {
+  it('stopScheduler flushes a pending local write (and cancels cloud)', () => {
     vi.useFakeTimers();
     const { engine, eventBus } = makeEngine({ cloud: true });
     const syncSpy = vi.spyOn(engine, 'sync');
@@ -549,8 +549,12 @@ describe('SyncEngine scheduler', () => {
     emitEdit(eventBus);
     engine.stopScheduler();
 
+    // The pending local debounce is flushed synchronously on stop; the cloud
+    // debouncer is cancelled, so only memory→local runs and no timer fires after.
+    expect(syncSpy).toHaveBeenCalledTimes(1);
+    expect(syncSpy).toHaveBeenCalledWith('memory', 'local', undefined);
     vi.advanceTimersByTime(10000);
-    expect(syncSpy).not.toHaveBeenCalled();
+    expect(syncSpy).toHaveBeenCalledTimes(1);
     syncSpy.mockRestore();
   });
 
@@ -613,11 +617,10 @@ describe('SyncEngine scheduler', () => {
 
   it('dispose stops scheduler', () => {
     vi.useFakeTimers();
-    const { engine, eventBus } = makeEngine({ cloud: true });
+    const { engine } = makeEngine({ cloud: true });
     const syncSpy = vi.spyOn(engine, 'sync');
 
     engine.startScheduler(undefined, true);
-    emitEdit(eventBus);
     engine.dispose();
 
     vi.advanceTimersByTime(10000);

--- a/tests/sync/sync-engine.test.ts
+++ b/tests/sync/sync-engine.test.ts
@@ -8,15 +8,17 @@ import { EventBus } from '@/reactive';
 import type { EntityEvent } from '@/reactive';
 import { Store } from '@/store';
 import { DEFAULT_OPTIONS } from '../helpers';
+import type { ResolvedFyreDbOptions } from '@/index';
 
-function makeEngine(opts?: { cloud?: boolean }) {
-  const store = new Store(DEFAULT_OPTIONS);
+function makeEngine(opts?: { cloud?: boolean; options?: ResolvedFyreDbOptions }) {
+  const options = opts?.options ?? DEFAULT_OPTIONS;
+  const store = new Store(options);
   const local = createDataAdapter();
   const cloud = opts?.cloud ? createDataAdapter() : undefined;
   const hlcRef = { current: createHlc('test') };
   const eventBus = new EventBus<EntityEvent>();
   const syncEventBus = new EventBus<SyncEvent>();
-  const engine = new SyncEngine(store, local, cloud, ['task'], hlcRef, eventBus, syncEventBus, DEFAULT_OPTIONS);
+  const engine = new SyncEngine(store, local, cloud, ['task'], hlcRef, eventBus, syncEventBus, options);
   return { engine, store, local, cloud, hlcRef, eventBus, syncEventBus };
 }
 
@@ -520,19 +522,31 @@ describe('SyncEngine scheduler', () => {
     vi.useRealTimers();
   });
 
-  it('startScheduler begins periodic timers', () => {
+  const emitEdit = (bus: EventBus<EntityEvent>) =>
+    bus.emit({ entityName: 'task', source: 'user', updates: ['t1'], deletes: [] });
+
+  const SHORT: ResolvedFyreDbOptions = {
+    ...DEFAULT_OPTIONS,
+    localFlushDebounceMs: 20,
+    localFlushMaxWaitMs: 40,
+    cloudSyncDebounceMs: 20,
+    cloudSyncMaxWaitMs: 40,
+  };
+
+  it('starts and stops without throwing', () => {
     vi.useFakeTimers();
-    const { engine } = makeEngine();
+    const { engine } = makeEngine({ cloud: true });
     engine.startScheduler(undefined, true);
     engine.stopScheduler();
   });
 
-  it('stopScheduler clears timers', () => {
+  it('stopScheduler cancels a pending debounced flush', () => {
     vi.useFakeTimers();
-    const { engine } = makeEngine();
+    const { engine, eventBus } = makeEngine({ cloud: true });
     const syncSpy = vi.spyOn(engine, 'sync');
 
     engine.startScheduler(undefined, true);
+    emitEdit(eventBus);
     engine.stopScheduler();
 
     vi.advanceTimersByTime(10000);
@@ -540,13 +554,14 @@ describe('SyncEngine scheduler', () => {
     syncSpy.mockRestore();
   });
 
-  it('local flush interval calls sync memory→local on tick', () => {
+  it('local flush fires memory→local after a user edit (debounced)', () => {
     vi.useFakeTimers();
-    const { engine } = makeEngine();
+    const { engine, eventBus } = makeEngine({ cloud: true });
     const syncSpy = vi.spyOn(engine, 'sync');
 
     engine.startScheduler(undefined, true);
-    vi.advanceTimersByTime(2000);
+    emitEdit(eventBus);
+    vi.advanceTimersByTime(DEFAULT_OPTIONS.localFlushDebounceMs);
 
     expect(syncSpy).toHaveBeenCalledWith('memory', 'local', undefined);
 
@@ -554,15 +569,31 @@ describe('SyncEngine scheduler', () => {
     syncSpy.mockRestore();
   });
 
-  it('does not start cloud timer when hasCloud is false', () => {
+  it('sync-source events do not trigger a flush', () => {
     vi.useFakeTimers();
-    const { engine } = makeEngine();
+    const { engine, eventBus } = makeEngine({ cloud: true });
+    const syncSpy = vi.spyOn(engine, 'sync');
+
+    engine.startScheduler(undefined, true);
+    eventBus.emit({ entityName: 'task', source: 'sync', updates: ['t1'], deletes: [] });
+    vi.advanceTimersByTime(DEFAULT_OPTIONS.cloudSyncMaxWaitMs + 1000);
+
+    expect(syncSpy).not.toHaveBeenCalled();
+    engine.stopScheduler();
+    syncSpy.mockRestore();
+  });
+
+  it('does not arm cloud sync when hasCloud is false', () => {
+    vi.useFakeTimers();
+    const { engine, eventBus } = makeEngine({ cloud: false });
     const syncSpy = vi.spyOn(engine, 'sync');
 
     engine.startScheduler(undefined, false);
-    vi.advanceTimersByTime(10000);
+    emitEdit(eventBus);
+    vi.advanceTimersByTime(DEFAULT_OPTIONS.cloudSyncMaxWaitMs + 1000);
 
     const calls = syncSpy.mock.calls;
+    expect(calls.length).toBeGreaterThan(0);
     expect(calls.every(c => c[0] === 'memory' && c[1] === 'local')).toBe(true);
 
     engine.stopScheduler();
@@ -571,7 +602,7 @@ describe('SyncEngine scheduler', () => {
 
   it('stopScheduler is safe to call multiple times', () => {
     vi.useFakeTimers();
-    const { engine } = makeEngine();
+    const { engine } = makeEngine({ cloud: false });
 
     engine.startScheduler(undefined, false);
     expect(() => {
@@ -582,10 +613,11 @@ describe('SyncEngine scheduler', () => {
 
   it('dispose stops scheduler', () => {
     vi.useFakeTimers();
-    const { engine } = makeEngine();
+    const { engine, eventBus } = makeEngine({ cloud: true });
     const syncSpy = vi.spyOn(engine, 'sync');
 
     engine.startScheduler(undefined, true);
+    emitEdit(eventBus);
     engine.dispose();
 
     vi.advanceTimersByTime(10000);
@@ -594,21 +626,23 @@ describe('SyncEngine scheduler', () => {
   });
 
   it('catches local flush errors without crashing', async () => {
-    const { engine, local } = makeEngine();
+    const { engine, local, eventBus } = makeEngine({ cloud: true, options: SHORT });
     local.read = async () => { throw new Error('write failed'); };
 
     engine.startScheduler(undefined, true);
-    await new Promise(r => setTimeout(r, 3000));
+    emitEdit(eventBus);
+    await new Promise(r => setTimeout(r, 100));
     await engine.drain().catch(() => {});
     engine.stopScheduler();
   });
 
   it('catches cloud sync errors without crashing', async () => {
-    const { engine, cloud } = makeEngine({ cloud: true });
+    const { engine, cloud, eventBus } = makeEngine({ cloud: true, options: SHORT });
     cloud!.read = async () => { throw new Error('network failed'); };
 
     engine.startScheduler(undefined, true);
-    await new Promise(r => setTimeout(r, 3000));
+    emitEdit(eventBus);
+    await new Promise(r => setTimeout(r, 100));
     await engine.drain().catch(() => {});
     engine.stopScheduler();
   });

--- a/tests/sync/sync-scheduler.test.ts
+++ b/tests/sync/sync-scheduler.test.ts
@@ -46,7 +46,7 @@ describe('SyncEngine scheduler', () => {
     engine.stopScheduler();
   });
 
-  it('stopScheduler cancels a pending debounced flush', () => {
+  it('stopScheduler flushes a pending local write (and cancels cloud)', () => {
     vi.useFakeTimers();
     const { engine, eventBus } = makeEngine();
     const syncSpy = vi.spyOn(engine, 'sync');
@@ -55,8 +55,12 @@ describe('SyncEngine scheduler', () => {
     emitEdit(eventBus);
     engine.stopScheduler();
 
+    // The pending local debounce is flushed synchronously on stop; the cloud
+    // debouncer is cancelled, so only memory→local runs and no timer fires after.
+    expect(syncSpy).toHaveBeenCalledTimes(1);
+    expect(syncSpy).toHaveBeenCalledWith('memory', 'local', undefined);
     vi.advanceTimersByTime(10000);
-    expect(syncSpy).not.toHaveBeenCalled();
+    expect(syncSpy).toHaveBeenCalledTimes(1);
     syncSpy.mockRestore();
   });
 
@@ -142,11 +146,10 @@ describe('SyncEngine scheduler', () => {
 
   it('dispose stops scheduler', () => {
     vi.useFakeTimers();
-    const { engine, eventBus } = makeEngine();
+    const { engine } = makeEngine();
     const syncSpy = vi.spyOn(engine, 'sync');
 
     engine.startScheduler(undefined, true);
-    emitEdit(eventBus);
     engine.dispose();
 
     vi.advanceTimersByTime(10000);

--- a/tests/sync/sync-scheduler.test.ts
+++ b/tests/sync/sync-scheduler.test.ts
@@ -8,36 +8,51 @@ import { DEFAULT_OPTIONS } from '../helpers';
 import { SyncEngine } from '@/sync';
 import type { SyncEvent } from '@/sync';
 import { ReactiveFlag } from '@/utils';
+import type { ResolvedFyreDbOptions } from '@/index';
 
-function makeEngine(opts?: { cloud?: boolean }) {
-  const store = new Store(DEFAULT_OPTIONS);
+function makeEngine(opts?: { cloud?: boolean; options?: ResolvedFyreDbOptions }) {
+  const options = opts?.options ?? DEFAULT_OPTIONS;
+  const store = new Store(options);
   const local = createDataAdapter();
   const cloud = opts?.cloud !== false ? createDataAdapter() : undefined;
   const hlcRef = { current: createHlc('test') };
   const eventBus = new EventBus<EntityEvent>();
   const syncEventBus = new EventBus<SyncEvent>();
-  const engine = new SyncEngine(store, local, cloud, ['task'], hlcRef, eventBus, syncEventBus, DEFAULT_OPTIONS);
-  return { engine, store, local, cloud };
+  const engine = new SyncEngine(store, local, cloud, ['task'], hlcRef, eventBus, syncEventBus, options);
+  return { engine, store, local, cloud, eventBus };
 }
+
+const emitEdit = (bus: EventBus<EntityEvent>) =>
+  bus.emit({ entityName: 'task', source: 'user', updates: ['t1'], deletes: [] });
+
+const SHORT_OPTIONS: ResolvedFyreDbOptions = {
+  ...DEFAULT_OPTIONS,
+  localFlushDebounceMs: 20,
+  localFlushMaxWaitMs: 40,
+  cloudSyncDebounceMs: 20,
+  cloudSyncMaxWaitMs: 40,
+  cloudPullIntervalMs: 100,
+};
 
 describe('SyncEngine scheduler', () => {
   afterEach(() => {
     vi.useRealTimers();
   });
 
-  it('startScheduler begins periodic timers', () => {
+  it('startScheduler begins the scheduler', () => {
     vi.useFakeTimers();
     const { engine } = makeEngine();
     engine.startScheduler(undefined, true);
     engine.stopScheduler();
   });
 
-  it('stopScheduler clears timers', () => {
+  it('stopScheduler cancels a pending debounced flush', () => {
     vi.useFakeTimers();
-    const { engine } = makeEngine();
+    const { engine, eventBus } = makeEngine();
     const syncSpy = vi.spyOn(engine, 'sync');
 
     engine.startScheduler(undefined, true);
+    emitEdit(eventBus);
     engine.stopScheduler();
 
     vi.advanceTimersByTime(10000);
@@ -45,13 +60,14 @@ describe('SyncEngine scheduler', () => {
     syncSpy.mockRestore();
   });
 
-  it('local flush interval calls sync memory→local on tick', () => {
+  it('local flush fires memory→local after a user edit (debounced)', () => {
     vi.useFakeTimers();
-    const { engine } = makeEngine();
+    const { engine, eventBus } = makeEngine();
     const syncSpy = vi.spyOn(engine, 'sync');
 
     engine.startScheduler(undefined, true);
-    vi.advanceTimersByTime(2000);
+    emitEdit(eventBus);
+    vi.advanceTimersByTime(DEFAULT_OPTIONS.localFlushDebounceMs);
 
     expect(syncSpy).toHaveBeenCalledWith('memory', 'local', undefined);
 
@@ -59,15 +75,54 @@ describe('SyncEngine scheduler', () => {
     syncSpy.mockRestore();
   });
 
-  it('does not start cloud timer when hasCloud is false', () => {
+  it('does not exceed the max-wait ceiling during sustained edits', () => {
     vi.useFakeTimers();
-    const { engine } = makeEngine({ cloud: false });
+    const { engine, eventBus } = makeEngine();
+    const syncSpy = vi.spyOn(engine, 'sync');
+
+    engine.startScheduler(undefined, true);
+    // Keep editing just under the debounce window so the trailing timer never
+    // settles; the ceiling must still force a flush.
+    const step = DEFAULT_OPTIONS.localFlushDebounceMs - 100;
+    for (let elapsed = 0; elapsed < DEFAULT_OPTIONS.localFlushMaxWaitMs + step; elapsed += step) {
+      emitEdit(eventBus);
+      vi.advanceTimersByTime(step);
+    }
+
+    expect(syncSpy).toHaveBeenCalledWith('memory', 'local', undefined);
+
+    engine.stopScheduler();
+    syncSpy.mockRestore();
+  });
+
+  it('pull backstop timer runs a cloud cycle without any edits', async () => {
+    vi.useFakeTimers();
+    const { engine } = makeEngine({ options: SHORT_OPTIONS });
+    const syncSpy = vi.spyOn(engine, 'sync');
+
+    engine.startScheduler(undefined, true);
+    // No edits emitted — only the periodic pull timer should fire. Advance with
+    // the async variant so the cloud cycle's awaited steps (memory→local, then
+    // local→cloud) actually run.
+    await vi.advanceTimersByTimeAsync(SHORT_OPTIONS.cloudPullIntervalMs + 10);
+
+    expect(syncSpy).toHaveBeenCalledWith('local', 'cloud', undefined);
+
+    engine.stopScheduler();
+    syncSpy.mockRestore();
+  });
+
+  it('does not arm cloud sync when hasCloud is false', () => {
+    vi.useFakeTimers();
+    const { engine, eventBus } = makeEngine({ cloud: false });
     const syncSpy = vi.spyOn(engine, 'sync');
 
     engine.startScheduler(undefined, false);
-    vi.advanceTimersByTime(10000);
+    emitEdit(eventBus);
+    vi.advanceTimersByTime(DEFAULT_OPTIONS.cloudSyncMaxWaitMs + 1000);
 
     const calls = syncSpy.mock.calls;
+    expect(calls.length).toBeGreaterThan(0);
     expect(calls.every(c => c[0] === 'memory' && c[1] === 'local')).toBe(true);
 
     engine.stopScheduler();
@@ -87,10 +142,11 @@ describe('SyncEngine scheduler', () => {
 
   it('dispose stops scheduler', () => {
     vi.useFakeTimers();
-    const { engine } = makeEngine();
+    const { engine, eventBus } = makeEngine();
     const syncSpy = vi.spyOn(engine, 'sync');
 
     engine.startScheduler(undefined, true);
+    emitEdit(eventBus);
     engine.dispose();
 
     vi.advanceTimersByTime(10000);
@@ -99,82 +155,57 @@ describe('SyncEngine scheduler', () => {
   });
 
   it('catches local flush errors without crashing', async () => {
-    const { engine, local } = makeEngine();
+    const { engine, local, eventBus } = makeEngine({ options: SHORT_OPTIONS });
     local.read = async () => { throw new Error('write failed'); };
 
     engine.startScheduler(undefined, true);
-    await new Promise(r => setTimeout(r, 3000));
+    emitEdit(eventBus);
+    await new Promise(r => setTimeout(r, 100));
     await engine.drain().catch(() => {});
     engine.stopScheduler();
   });
 
   it('catches cloud sync errors without crashing', async () => {
-    const { engine, cloud } = makeEngine();
+    const { engine, cloud, eventBus } = makeEngine({ options: SHORT_OPTIONS });
     cloud!.read = async () => { throw new Error('network failed'); };
 
     engine.startScheduler(undefined, true);
-    await new Promise(r => setTimeout(r, 3000));
+    emitEdit(eventBus);
+    await new Promise(r => setTimeout(r, 100));
     await engine.drain().catch(() => {});
     engine.stopScheduler();
   });
 
-  it('cloud scheduler clears dirtyTracker on success', async () => {
-    // Create engine with very short cloud interval
-    const store = new Store(DEFAULT_OPTIONS);
-    const local = createDataAdapter();
-    const cloud = createDataAdapter();
-    const hlcRef = { current: createHlc('test') };
-    const eventBus = new EventBus<EntityEvent>();
-    const syncEventBus = new EventBus<SyncEvent>();
-    const engine = new SyncEngine(store, local, cloud, ['task'], hlcRef, eventBus, syncEventBus, {
-      ...DEFAULT_OPTIONS,
-      cloudSyncIntervalMs: 100,
-      localFlushIntervalMs: 50,
-    });
+  it('cloud sync clears dirtyTracker on success after an edit', async () => {
+    const { engine, eventBus } = makeEngine({ options: SHORT_OPTIONS });
 
     const tracker = new ReactiveFlag();
     tracker.set();
     expect(tracker.value).toBe(true);
 
     engine.startScheduler(undefined, true, tracker);
-    await new Promise(r => setTimeout(r, 500));
+    emitEdit(eventBus);
+    await new Promise(r => setTimeout(r, 300));
     await engine.drain().catch(() => {});
     engine.stopScheduler();
 
     expect(tracker.value).toBe(false);
   });
 
-  it('cloud scheduler catches errors with short interval', async () => {
-    const store = new Store(DEFAULT_OPTIONS);
-    const local = createDataAdapter();
-    const cloud = createDataAdapter();
-    const hlcRef = { current: createHlc('test') };
-    const eventBus = new EventBus<EntityEvent>();
-    const syncEventBus = new EventBus<SyncEvent>();
-    const engine = new SyncEngine(store, local, cloud, ['task'], hlcRef, eventBus, syncEventBus, {
-      ...DEFAULT_OPTIONS,
-      cloudSyncIntervalMs: 100,
-      localFlushIntervalMs: 50,
-    });
-
-    cloud.read = async () => { throw new Error('cloud failure'); };
+  it('cloud sync catches errors with short debounce', async () => {
+    const { engine, cloud, eventBus } = makeEngine({ options: SHORT_OPTIONS });
+    cloud!.read = async () => { throw new Error('cloud failure'); };
 
     engine.startScheduler(undefined, true);
-    await new Promise(r => setTimeout(r, 500));
+    emitEdit(eventBus);
+    await new Promise(r => setTimeout(r, 300));
     await engine.drain().catch(() => {});
     engine.stopScheduler();
   });
 
-  it('uses default intervals when options are undefined', () => {
+  it('starts with default options', () => {
     vi.useFakeTimers();
-    const store = new Store(DEFAULT_OPTIONS);
-    const local = createDataAdapter();
-    const cloud = createDataAdapter();
-    const hlcRef = { current: createHlc('test') };
-    const eventBus = new EventBus<EntityEvent>();
-    const syncEventBus = new EventBus<SyncEvent>();
-    // Create engine with default options
-    const engine = new SyncEngine(store, local, cloud, ['task'], hlcRef, eventBus, syncEventBus, DEFAULT_OPTIONS);
+    const { engine } = makeEngine();
 
     engine.startScheduler(undefined, true);
     engine.stopScheduler();

--- a/tests/tenant/sharing.test.ts
+++ b/tests/tenant/sharing.test.ts
@@ -23,6 +23,7 @@ function stubSyncEngine(): SyncEngineType {
   return {
     sync: async () => ({ result: { changesForA: [], changesForB: [], stale: false, maxHlc: undefined }, deduplicated: false }),
     run: async () => [],
+    runCloudCycle: async () => ({ entitiesUpdated: 0, conflictsResolved: 0, partitionsSynced: 0 }),
     ensurePartition: async () => {},
     startScheduler: () => {},
     stopScheduler: () => {},

--- a/tests/tenant/tenant-manager.test.ts
+++ b/tests/tenant/tenant-manager.test.ts
@@ -31,6 +31,7 @@ function stubSyncEngine(): SyncEngineType {
       deduplicated: false,
     }),
     run: async () => [],
+    runCloudCycle: async () => ({ entitiesUpdated: 0, conflictsResolved: 0, partitionsSynced: 0 }),
     ensurePartition: async () => {},
     startScheduler: () => {},
     stopScheduler: () => {},


### PR DESCRIPTION
## Summary
Replaces the fixed-interval sync scheduler with debounced, edit-driven persistence for both local and cloud.

### Behavior
- **Local flush** (memory to local): debounced on user edits — 500ms settle / 3s ceiling.
- **Cloud sync** (memory to local to cloud to memory): debounced on user edits — 10s settle / 60s ceiling. Clears the dirty flag on success.
- **Cloud pull backstop**: retained periodic timer (cloudPullIntervalMs, default 5min) runs the same cloud cycle so an idle device still receives remote changes (pulls can't be edit-driven).
- Only user-originated entity events arm the debouncers; sync-imported changes never re-trigger a sync.
- **isDirty** is now only set when a cloud adapter is configured — local-only mode is never dirty (the local flush is the durable save).

### API changes
FyreDbOptions: replaces localFlushIntervalMs / cloudSyncIntervalMs with:
- localFlushDebounceMs (500), localFlushMaxWaitMs (3000)
- cloudSyncDebounceMs (10000), cloudSyncMaxWaitMs (60000)
- cloudPullIntervalMs (300000)

Adds a Debouncer utility (trailing debounce + max-wait ceiling).

### Tests
Full core suite green: 50 files / 593 tests. Scheduler tests rewritten to be edit-driven (emit user event to trigger debounced flush), plus pull-backstop and max-wait ceiling coverage.

Docs (README, docs/sync.md, docs/getting-started.md) updated.