### PR TITLE
fix(sync): flush pending local write on page hide/unload

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fyre-db/core",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Offline-first reactive data framework — the @fyre-db core",
   "homepage": "https://github.com/fyre-db/core#readme",
   "bugs": {

--- a/src/sync/sync-engine.ts
+++ b/src/sync/sync-engine.ts
@@ -190,6 +190,8 @@ export class SyncEngine {
   private localDebouncer: Debouncer | null = null;
   private cloudDebouncer: Debouncer | null = null;
   private editSub: Subscription | null = null;
+  private unloadFlushHandler: (() => void) | null = null;
+  private visibilityFlushHandler: (() => void) | null = null;
 
   /**
    * Start edit-driven persistence for the active tenant.
@@ -237,6 +239,8 @@ export class SyncEngine {
       this.cloudDebouncer?.schedule();
     });
 
+    this.registerUnloadFlush();
+
     log.sync('scheduler started (local=%d/%dms, cloud=%d/%dms, pull=%dms)',
       this.options.localFlushDebounceMs, this.options.localFlushMaxWaitMs,
       this.options.cloudSyncDebounceMs, this.options.cloudSyncMaxWaitMs,
@@ -247,6 +251,7 @@ export class SyncEngine {
   stopScheduler(): void {
     this.editSub?.unsubscribe();
     this.editSub = null;
+    this.unregisterUnloadFlush();
     // Flush (not cancel) any pending local write so stopping never drops edits.
     this.localDebouncer?.flush();
     this.localDebouncer = null;
@@ -262,6 +267,36 @@ export class SyncEngine {
     this.sync('memory', 'local', tenant).catch((err: unknown) => {
       log.sync.error('local flush failed: %O', err);
     });
+  }
+
+  /**
+   * Flush the pending local write when the page is hidden or torn down (reload,
+   * navigation, tab close). Without this a debounced `memory → local` write can
+   * be lost if the page unloads inside the debounce window, dropping a just-made
+   * edit. Cloud propagation is intentionally not attempted here (it is
+   * async/network and unreliable during unload); the higher-HLC local row wins
+   * the next startup merge and is re-pushed to cloud then.
+   */
+  private registerUnloadFlush(): void {
+    if (typeof window === 'undefined' || typeof document === 'undefined') return;
+    const flush = (): void => { this.localDebouncer?.flush(); };
+    this.unloadFlushHandler = flush;
+    this.visibilityFlushHandler = (): void => {
+      if (document.visibilityState === 'hidden') flush();
+    };
+    window.addEventListener('pagehide', flush);
+    document.addEventListener('visibilitychange', this.visibilityFlushHandler);
+  }
+
+  private unregisterUnloadFlush(): void {
+    if (this.unloadFlushHandler !== null && typeof window !== 'undefined') {
+      window.removeEventListener('pagehide', this.unloadFlushHandler);
+    }
+    if (this.visibilityFlushHandler !== null && typeof document !== 'undefined') {
+      document.removeEventListener('visibilitychange', this.visibilityFlushHandler);
+    }
+    this.unloadFlushHandler = null;
+    this.visibilityFlushHandler = null;
   }
 
   /**

--- a/tests/sync/sync-scheduler.test.ts
+++ b/tests/sync/sync-scheduler.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, afterEach } from 'vitest';
+import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest';
 import { createDataAdapter } from '../helpers';
 import { createHlc } from '@/hlc';
 import { EventBus } from '@/reactive';
@@ -212,6 +212,95 @@ describe('SyncEngine scheduler', () => {
 
     engine.startScheduler(undefined, true);
     engine.stopScheduler();
+  });
+});
+
+type FakeEventTarget = {
+  addEventListener: (type: string, fn: () => void) => void;
+  removeEventListener: (type: string, fn: () => void) => void;
+  dispatch: (type: string) => void;
+  count: (type: string) => number;
+};
+
+function makeFakeTarget(): FakeEventTarget {
+  const listeners = new Map<string, Set<() => void>>();
+  return {
+    addEventListener: (type, fn) => {
+      const set = listeners.get(type) ?? new Set<() => void>();
+      set.add(fn);
+      listeners.set(type, set);
+    },
+    removeEventListener: (type, fn) => { listeners.get(type)?.delete(fn); },
+    dispatch: (type) => { for (const fn of listeners.get(type) ?? []) fn(); },
+    count: (type) => listeners.get(type)?.size ?? 0,
+  };
+}
+
+describe('SyncEngine scheduler flush-on-unload', () => {
+  let win: FakeEventTarget;
+  let doc: FakeEventTarget & { visibilityState: string };
+
+  beforeEach(() => {
+    win = makeFakeTarget();
+    doc = { ...makeFakeTarget(), visibilityState: 'hidden' };
+    vi.stubGlobal('window', win);
+    vi.stubGlobal('document', doc);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('flushes the pending local write on pagehide', () => {
+    const { engine, eventBus } = makeEngine();
+    const syncSpy = vi.spyOn(engine, 'sync');
+
+    engine.startScheduler(undefined, true);
+    emitEdit(eventBus);
+    win.dispatch('pagehide');
+
+    expect(syncSpy).toHaveBeenCalledWith('memory', 'local', undefined);
+    engine.stopScheduler();
+    syncSpy.mockRestore();
+  });
+
+  it('flushes the pending local write when the page becomes hidden', () => {
+    const { engine, eventBus } = makeEngine();
+    const syncSpy = vi.spyOn(engine, 'sync');
+
+    engine.startScheduler(undefined, true);
+    emitEdit(eventBus);
+    doc.dispatch('visibilitychange');
+
+    expect(syncSpy).toHaveBeenCalledWith('memory', 'local', undefined);
+    engine.stopScheduler();
+    syncSpy.mockRestore();
+  });
+
+  it('does not flush on visibilitychange while the page is visible', () => {
+    const { engine, eventBus } = makeEngine();
+    const syncSpy = vi.spyOn(engine, 'sync');
+
+    engine.startScheduler(undefined, true);
+    emitEdit(eventBus);
+    doc.visibilityState = 'visible';
+    doc.dispatch('visibilitychange');
+
+    expect(syncSpy).not.toHaveBeenCalled();
+    engine.stopScheduler();
+    syncSpy.mockRestore();
+  });
+
+  it('removes the unload listeners on stopScheduler', () => {
+    const { engine } = makeEngine();
+
+    engine.startScheduler(undefined, true);
+    expect(win.count('pagehide')).toBe(1);
+    expect(doc.count('visibilitychange')).toBe(1);
+
+    engine.stopScheduler();
+    expect(win.count('pagehide')).toBe(0);
+    expect(doc.count('visibilitychange')).toBe(0);
   });
 });
 


### PR DESCRIPTION
## Problem

A debounced memory -> local write can be lost if the page reloads or navigates **inside** the local-flush debounce window (default 500ms). On the next startup merge, a still-present cloud delete-tombstone then wins and re-deletes the row -- surfacing as "just-added connection disappears after reload".

## Fix

Register pagehide + isibilitychange(hidden) listeners in the sync scheduler that **synchronously flush** the pending local write, guaranteeing the higher-HLC row reaches localStorage before teardown (so it wins the next merge and re-propagates to cloud). Cloud push is intentionally not attempted on unload (async/network, unreliable during teardown).

- Listeners registered in startScheduler, torn down in stopScheduler (and thus dispose).
- Guarded for non-browser / test environments via 	ypeof window/document checks.
- Version bump 0.1.2 -> 0.1.3.

## Tests

Adds a lush-on-unload describe block (fake window/document via i.stubGlobal): flush on pagehide, flush on isibilitychange->hidden, no-op while visible, listener cleanup on stop. Full suite: 606 passed, lint clean.