### PR TITLE
fix(sync): prevent lazy hydration from clobbering concurrent writes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fyre-db/core",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Offline-first reactive data framework — the @fyre-db core",
   "homepage": "https://github.com/fyre-db/core#readme",
   "bugs": {

--- a/src/repo/repository.ts
+++ b/src/repo/repository.ts
@@ -1,6 +1,6 @@
 import { startWith, map, distinctUntilChanged } from 'rxjs/operators';
 import type { Hlc } from '@/hlc';
-import { tick } from '@/hlc';
+import { tick, compareHlc } from '@/hlc';
 import type { EntityDefinition, BaseEntity } from '@/schema';
 import { formatEntityId } from '@/schema';
 import { generateId, parseEntityKey, parseCompositeKey } from '@/utils';
@@ -51,6 +51,32 @@ export class Repository<T> {
     return this.store.getEntity(entityKey, id) as (T & BaseEntity) | undefined;
   }
 
+  /**
+   * Mint the next HLC for a mutation of `id`, causally after **every** clock
+   * already recorded for that key: the device clock, the id's current entity
+   * hlc, and any live tombstone hlc for the id. Ticking only against
+   * `this.hlc.current` is unsafe — after a reload the device clock restarts at
+   * `{timestamp:0}` and only catches up on the next sync, so a save/delete
+   * could otherwise mint an hlc that is not strictly newer than a value or
+   * tombstone already in the store and lose the subsequent merge (e.g. a
+   * reconnect being re-deleted by its own stale tombstone). Advances
+   * `this.hlc.current` to the minted value.
+   */
+  private nextHlc(
+    entityKey: string,
+    id: string,
+    existing: (T & BaseEntity) | undefined,
+  ): Hlc {
+    let reference: Hlc | undefined = existing?.hlc;
+    const tombstone = this.store.getTombstones(entityKey).get(id);
+    if (tombstone && (!reference || compareHlc(tombstone, reference) > 0)) {
+      reference = tombstone;
+    }
+    const next = tick(this.hlc.current, reference);
+    this.hlc.current = next;
+    return next;
+  }
+
   private saveToStore(partial: T & Partial<BaseEntity>): string {
     let id: string;
     let entityKey: string;
@@ -76,7 +102,7 @@ export class Repository<T> {
 
     const existing = this.store.getEntity(entityKey, id) as (T & BaseEntity) | undefined;
 
-    const nextHlc = tick(this.hlc.current);
+    const nextHlc = this.nextHlc(entityKey, id, existing);
     const now = new Date();
 
     const entity = {
@@ -119,12 +145,12 @@ export class Repository<T> {
     const entity = this.store.getEntity(entityKey, id) as (T & BaseEntity) | undefined;
     if (entity) {
       // A delete is a new operation: stamp the tombstone with a freshly ticked
-      // HLC (causally after the entity's own hlc and carrying a current
-      // timestamp). Reusing `entity.hlc` would make the tombstone equal to —
-      // not newer than — the value, and its stale timestamp could be pruned by
-      // tombstone-retention before the delete propagates, resurrecting the row.
-      const nextHlc = tick(this.hlc.current);
-      this.hlc.current = nextHlc;
+      // HLC (causally after the entity's own hlc and any prior tombstone, and
+      // carrying a current timestamp). Reusing `entity.hlc` would make the
+      // tombstone equal to — not newer than — the value, and its stale
+      // timestamp could be pruned by tombstone-retention before the delete
+      // propagates, resurrecting the row.
+      const nextHlc = this.nextHlc(entityKey, id, entity);
       this.store.setTombstone(entityKey, id, nextHlc);
     }
     const deleted = this.store.deleteEntity(entityKey, id);

--- a/src/sync/sync-engine.ts
+++ b/src/sync/sync-engine.ts
@@ -6,7 +6,7 @@ import type { EventBus } from '@/reactive';
 import type { EntityEvent } from '@/reactive';
 import type { EntityStore } from '@/store';
 import type { BlobMigration } from '@/schema/migration';
-import type { DataAdapter, AllIndexes } from '@/persistence';
+import type { DataAdapter, AllIndexes, PartitionBlob } from '@/persistence';
 import { parseCompositeKey } from '@/utils';
 import type { ReactiveFlag } from '@/utils';
 import { Debouncer } from '@/utils';
@@ -20,6 +20,7 @@ import type {
   SyncEntityChange, SyncResult,
 } from './types';
 import { syncBetween } from './unified';
+import { mergePartition } from './merge';
 import type { PartitionFilter } from './unified';
 import { MarkerStore } from './marker-store';
 import { log } from '@/log';
@@ -355,8 +356,9 @@ export class SyncEngine {
     if (hasPartitionIndex(localIndexes, entityName, partitionKey)) {
       const blob = await this.localAdapter.read(tenant, entityKey);
       if (blob) {
-        await this.store.write(tenant, entityKey, blob);
-        this.emitEntityChangesFromBlob(entityName, blob);
+        const effective = await this.mergeConcurrentWrites(tenant, entityName, entityKey, blob);
+        await this.store.write(tenant, entityKey, effective);
+        this.emitEntityChangesFromBlob(entityName, effective);
         log.sync('lazy-loaded %s from local', entityKey);
         return;
       }
@@ -369,9 +371,10 @@ export class SyncEngine {
         if (hasPartitionIndex(cloudIndexes, entityName, partitionKey)) {
           const blob = await this.cloudAdapter.read(tenant, entityKey);
           if (blob) {
-            await this.localAdapter.write(tenant, entityKey, blob);
-            await this.store.write(tenant, entityKey, blob);
-            this.emitEntityChangesFromBlob(entityName, blob);
+            const effective = await this.mergeConcurrentWrites(tenant, entityName, entityKey, blob);
+            await this.localAdapter.write(tenant, entityKey, effective);
+            await this.store.write(tenant, entityKey, effective);
+            this.emitEntityChangesFromBlob(entityName, effective);
             log.sync('lazy-loaded %s from cloud', entityKey);
             return;
           }
@@ -384,6 +387,33 @@ export class SyncEngine {
     }
 
     log.sync('lazy-load %s: not found in any tier', entityKey);
+  }
+
+  /**
+   * Lazy hydration reads a partition from persistence and writes it into the
+   * in-memory store. Because the read is async, a user mutation (e.g. an OAuth
+   * callback saving a reconnected account) can land in memory during the gap.
+   * Blindly writing the loaded blob would clobber that un-persisted edit and
+   * resurrect a stale tombstone. When memory already holds the partition, merge
+   * the loaded blob with the current in-memory state (HLC-resolved, identical
+   * to a sync merge) so concurrent local writes win when they are causally
+   * newer. When memory has no partition (the normal case) the loaded blob is
+   * returned unchanged.
+   */
+  private async mergeConcurrentWrites(
+    tenant: Tenant | undefined,
+    entityName: string,
+    entityKey: string,
+    loadedBlob: PartitionBlob,
+  ): Promise<PartitionBlob> {
+    if (!this.store.hasPartition(entityKey)) return loadedBlob;
+    const memoryBlob = await this.store.read(tenant, entityKey);
+    if (!memoryBlob) return loadedBlob;
+    const merged = mergePartition(memoryBlob, loadedBlob, entityName);
+    return {
+      [entityName]: merged.entities,
+      deleted: { [entityName]: merged.tombstones },
+    };
   }
 
   private emitEntityChangesFromBlob(

--- a/tests/repo/tombstone-delete.test.ts
+++ b/tests/repo/tombstone-delete.test.ts
@@ -65,3 +65,66 @@ describe('Repository delete tombstone integration', () => {
     expect(tombstones.size).toBe(0);
   });
 });
+
+describe('Repository mutation HLC never lags stored state', () => {
+  const HOUR_MS = 3600_000;
+
+  it('save over an id with a future-dated tombstone mints an HLC newer than the tombstone', () => {
+    const store = new Store(DEFAULT_OPTIONS);
+    // Device clock starts fresh (timestamp 0), as after a reload before any sync.
+    const hlc = { current: createHlc('device1') };
+    const eventBus = new EventBus<EntityEvent>();
+    const repo = new Repository(taskDef, store, hlc, eventBus);
+
+    // A delete performed on another device whose clock is an hour ahead.
+    const id = 'task._.abc';
+    const futureTombstone = { timestamp: Date.now() + HOUR_MS, counter: 5, nodeId: 'device2' };
+    store.setTombstone('task._', id, futureTombstone);
+
+    // Re-adding the row (e.g. reconnecting an account) must win the next merge.
+    repo.save({ id, name: 'Reconnect' } as Task & { id: string });
+
+    const savedHlc = repo.get(id)!.hlc;
+    expect(compareHlc(savedHlc, futureTombstone)).toBeGreaterThan(0);
+    // The device clock is advanced too, so subsequent ops stay monotonic.
+    expect(compareHlc(hlc.current, futureTombstone)).toBeGreaterThan(0);
+  });
+
+  it('re-save over an entity whose HLC is ahead of the device clock still advances', () => {
+    const store = new Store(DEFAULT_OPTIONS);
+    const hlc = { current: createHlc('device1') };
+    const eventBus = new EventBus<EntityEvent>();
+    const repo = new Repository(taskDef, store, hlc, eventBus);
+
+    const id = 'task._.abc';
+    const futureHlc = { timestamp: Date.now() + HOUR_MS, counter: 2, nodeId: 'device2' };
+    store.setEntity('task._', id, {
+      id, name: 'Old', createdAt: new Date(), updatedAt: new Date(),
+      version: 1, device: 'device2', hlc: futureHlc,
+    });
+
+    repo.save({ id, name: 'New' } as Task & { id: string });
+
+    const savedHlc = repo.get(id)!.hlc;
+    expect(compareHlc(savedHlc, futureHlc)).toBeGreaterThan(0);
+  });
+
+  it('delete of an entity whose HLC is ahead mints a tombstone newer than the entity', () => {
+    const store = new Store(DEFAULT_OPTIONS);
+    const hlc = { current: createHlc('device1') };
+    const eventBus = new EventBus<EntityEvent>();
+    const repo = new Repository(taskDef, store, hlc, eventBus);
+
+    const id = 'task._.abc';
+    const futureHlc = { timestamp: Date.now() + HOUR_MS, counter: 2, nodeId: 'device2' };
+    store.setEntity('task._', id, {
+      id, name: 'Old', createdAt: new Date(), updatedAt: new Date(),
+      version: 1, device: 'device2', hlc: futureHlc,
+    });
+
+    repo.delete(id);
+
+    const tombstoneHlc = store.getTombstones('task._').get(id)!;
+    expect(compareHlc(tombstoneHlc, futureHlc)).toBeGreaterThan(0);
+  });
+});

--- a/tests/sync/sync-engine.test.ts
+++ b/tests/sync/sync-engine.test.ts
@@ -476,6 +476,80 @@ describe('SyncEngine', () => {
     expect(changed).toContain('task');
   });
 
+  it('does not clobber a concurrent in-memory write during lazy hydration', async () => {
+    const { engine, local, store } = makeEngine();
+
+    // Local holds only a (realistic, past-dated) tombstone for an id — the row
+    // was deleted earlier and never re-added on this device.
+    const tombstoneHlc = { timestamp: 500, counter: 0, nodeId: 'self' };
+    await local.write(undefined, 'task._', {
+      task: {},
+      deleted: { task: { 'task._.x': tombstoneHlc } },
+    });
+    await saveAllIndexes(local, undefined, {
+      task: { '_': { hash: 1, count: 0, deletedCount: 1, updatedAt: 500 } },
+    }, DEFAULT_OPTIONS);
+
+    // Gate the local read so hydration stays in flight while we simulate a user
+    // mutation (e.g. an OAuth callback save) landing in memory during the gap.
+    let release!: () => void;
+    const gate = new Promise<void>(resolve => { release = resolve; });
+    const origRead = local.read.bind(local);
+    let gated = true;
+    local.read = async (tenant, key) => {
+      if (gated && key === 'task._') { gated = false; await gate; }
+      return origRead(tenant, key);
+    };
+
+    const hydration = engine.ensurePartition(undefined, 'task', '_');
+
+    // Concurrent re-add with an HLC strictly newer than the tombstone.
+    store.setEntity('task._', 'task._.x', {
+      id: 'task._.x', title: 'Reconnect',
+      hlc: { timestamp: 1000, counter: 0, nodeId: 'self' },
+    });
+
+    release();
+    await hydration;
+
+    // The newer in-memory re-add must survive; the stale tombstone must not
+    // resurrect and delete it.
+    expect(store.getEntity('task._', 'task._.x')).toBeDefined();
+    expect(store.getTombstones('task._').has('task._.x')).toBe(false);
+  });
+
+  it('hydrates normally when a concurrent empty partition reads back as null', async () => {
+    const { engine, local, store } = makeEngine();
+
+    await local.write(undefined, 'task._', {
+      task: { 'task._.l1': { id: 'task._.l1', hlc: { timestamp: 500, counter: 0, nodeId: 'loc' } } },
+      deleted: { task: {} },
+    });
+    await saveAllIndexes(local, undefined, {
+      task: { '_': { hash: 1, count: 1, deletedCount: 0, updatedAt: 500 } },
+    }, DEFAULT_OPTIONS);
+
+    let release!: () => void;
+    const gate = new Promise<void>(resolve => { release = resolve; });
+    const origRead = local.read.bind(local);
+    let gated = true;
+    local.read = async (tenant, key) => {
+      if (gated && key === 'task._') { gated = false; await gate; }
+      return origRead(tenant, key);
+    };
+
+    const hydration = engine.ensurePartition(undefined, 'task', '_');
+
+    // A partition exists in memory but is empty with no tombstones, so
+    // store.read returns null — hydration falls back to the loaded blob.
+    await store.write(undefined, 'task._', { task: {}, deleted: { task: {} } });
+
+    release();
+    await hydration;
+
+    expect(store.getEntity('task._', 'task._.l1')).toBeDefined();
+  });
+
   it('emits one entity event when a sync moves two partitions of the same entity', async () => {
     const { engine, store, local, eventBus } = makeEngine();
     const taskEvents: { updates: string[] }[] = [];


### PR DESCRIPTION
## Problem

Re-adding a previously-disconnected entity (e.g. reconnecting an email account after an OAuth callback) could be **silently deleted on the next reload/sync**. Reproduced live in the Pai app with realistic, single-device data.

Two independent defects combined to cause it:

1. **Lazy hydration clobbered concurrent writes.** `SyncEngine.cascadeLoad` reads a partition asynchronously, then **overwrites** the in-memory partition with the loaded blob. `ConnectionsService` subscribes (`observeQuery` → async `ensurePartition`) and then **synchronously** saves the reconnect in the same tick (`consumeFeatureCreds`). The save landed in memory during the hydration gap, then hydration overwrote the whole partition — resurrecting the stale tombstone and dropping the re-add.

2. **Mutation HLCs could lag stored state.** `saveToStore` / `deleteFromStore` ticked only against `this.hlc.current`. After a reload the device clock restarts at `{timestamp:0}` and only catches up on the next sync, so a mutation could mint an HLC that is not strictly newer than an entity/tombstone already in the store and lose the subsequent merge.

## Fix

- **`cascadeLoad` merges instead of clobbers.** New `mergeConcurrentWrites` merges the loaded blob with current in-memory state via the existing HLC-resolved `mergePartition` when memory already holds the partition; otherwise the loaded blob is used unchanged (the normal path).
- **Mutations tick against existing state.** New `Repository.nextHlc` mints against the max of the device clock, the id's current entity HLC, and any live tombstone HLC — so a re-add is always causally after a prior delete, even when the device clock lags.

## Tests

- `tests/sync/sync-engine.test.ts`: regression test proving a concurrent, causally-newer in-memory write survives lazy hydration (stale tombstone does not resurrect); plus a fallback-path test.
- `tests/repo/tombstone-delete.test.ts`: 3 tests for minting HLCs newer than a future-dated tombstone / ahead-HLC entity on save and delete.
- Full suite: **611 passing**, lint clean. Changed files fully covered (`repository.ts` 100%, `sync-engine.ts` new code 100%).

## Version

`0.1.3` → `0.1.4`.
